### PR TITLE
Update README.md about docker option --init

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ The image uses [Sinatra Reloader](http://www.sinatrarb.com/contrib/reloader) for
 require 'sinatra/reloader' if development?
 ```
 
+To ensure that stopping of the container happens instantly, start docker with the `--init` option or use `init: true` when using a `docker-compose.yml` file.


### PR DESCRIPTION
Stopping the ruby-sinatra container does not stop instantly. Instead first happens nothing and after a timeout (default: 10s) the container is killed.
With the --init option from docker, an init process is started, which handles the SIGTERM-signal and shuts down the container instantly.